### PR TITLE
Colors added to config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -30,5 +30,16 @@
             "allNested": "**/*.html"
         },
         "sass": "main.scss"
-    }
+    },
+
+    "colors": {
+        "black": "\u001b[30m",
+        "red": "\u001b[31m",
+        "green": "\u001b[32m",
+        "yellow": "\u001b[33m",
+        "blue": "\u001b[34m",
+        "magenta": "\u001b[35m",
+        "cyan": "\u001b[36m",
+        "white": "\u001b[37m"
+   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,13 +16,7 @@ var gulp = require('gulp'),
     browserSync = require('browser-sync'),
     reload = browserSync.reload,
     browserChoice = 'default',
-
-    colors = {
-        black: '\033[0m',
-        red: '\033[31m',
-        green: '\033[32m',
-        blue: '\033[34m'
-    };
+    colors = config.colors;
 
 /**
  * CHOOSE A BROWSER OTHER THAN THE DEFAULT


### PR DESCRIPTION
Hey Roy,

I assume you were using the wrong character `\033` for `Esc`. I looked up ansi code sequences [here](http://ascii-table.com/ansi-escape-sequences.php). As it says, for changing foreground colors we should use this sequence : `Esc[Value;...;Valuem`. And the unicode for `Esc` is `001B`. So for color black,the sequence would be like this  : `u001b[30m` . Though according to [JSON RFC](http://www.ietf.org/rfc/rfc4627.txt)  all control characters `U0000` through `U001F` must be escaped with back slash, so black will be : `\u001b[30m` .

I put the colors array in config file and referenced them in the gulpfile.js. Tested it on `gulp clean` task and it worked.